### PR TITLE
Feature/view performance

### DIFF
--- a/packages/got-core/src/index.js
+++ b/packages/got-core/src/index.js
@@ -9,20 +9,8 @@ import {
     overPath,
     reduceObj,
     useResult,
+    getPathOr,
 } from '@gothub-team/got-util';
-
-const getPathOr = (or, path) => obj => {
-    let o = obj;
-    for (let i = 0; i < path.length; i += 1) {
-        const key = path[i];
-        if (key in o) {
-            o = o[key];
-        } else {
-            return or;
-        }
-    }
-    return o;
-};
 
 export const isEdgeTypesString = R.compose(
     ([fromType, toType]) => RA.lengthGt(0, fromType) && RA.lengthGt(0, toType),

--- a/packages/got-core/src/index.js
+++ b/packages/got-core/src/index.js
@@ -3,25 +3,13 @@ import * as R from 'ramda';
 import * as RA from 'ramda-adjunct';
 import {
     forEachCondObj,
+    getPath,
     mergeDeepLeft,
     mergeLeft,
     overPath,
     reduceObj,
     useResult,
 } from '@gothub-team/got-util';
-
-const getPath = (path, obj) => {
-    let o = obj;
-    for (let i = 0; i < path.length; i += 1) {
-        const key = path[i];
-        if (key in o) {
-            o = o[key];
-        } else {
-            return undefined;
-        }
-    }
-    return o;
-};
 
 const getPathOr = (or, path) => obj => {
     let o = obj;
@@ -257,19 +245,6 @@ export const selectPathFromStack = R.curry((path, stack, fnMergeLeft, state) => 
     });
     return acc;
 });
-
-// export const selectPathFromStack = R.curry((path, stack, fnMergeLeft, state) => R.reduce(
-//     (acc, graphName) => R.ifElse(
-//         R.hasPath([graphName, ...path]),
-//         R.compose(
-//             R.flip(fnMergeLeft)(acc),
-//             R.path([graphName, ...path]),
-//         ),
-//         R.always(acc),
-//     )(state),
-//     undefined,
-//     stack,
-// ));
 
 export const selectEdgeToIds = graph => (fromType, nodeId, toType, { reverse } = {}) => reverse
     ? R.pathOr({}, ['index', 'reverseEdges', toType, nodeId, fromType], graph)

--- a/packages/got-store/package.json
+++ b/packages/got-store/package.json
@@ -39,6 +39,7 @@
         "babel-plugin-transform-runtime": "^6.23.0",
         "babel-polyfill": "^6.26.0",
         "jest": "^28.1.0",
+        "uuid": "^8.3.2",
         "webpack": "^5.72.1",
         "webpack-cli": "4.9.2"
     },

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -11,6 +11,7 @@ import {
     overPath,
     useSubscriber,
     useResult,
+    mutAssocPath,
 } from '@gothub-team/got-util';
 import {
     mergeOverwriteGraphsLeft,
@@ -396,24 +397,6 @@ export const createStore = ({
         }
     };
     const selectView = (...stack) => view => state => {
-        const assocPath = (path, val) => obj => {
-            let o = obj;
-            for (let i = 0; i < path.length - 1; i += 1) {
-                const prop = path[i];
-                if (prop in o) {
-                    o = o[prop];
-                } else {
-                    o[prop] = {};
-                    o = o[prop];
-                }
-            }
-
-            const lastProp = path[path.length - 1];
-            o[lastProp] = val;
-
-            return obj;
-        };
-
         const [getViewTree, setViewTree, overViewTree] = useResult({});
         const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => {
             const res = reverse
@@ -438,7 +421,7 @@ export const createStore = ({
                     bag.files = selectFiles(...stack)(nodeId)(state);
                 }
 
-                overViewTree(assocPath(nodeViewPath, bag));
+                overViewTree(mutAssocPath(nodeViewPath, bag));
             },
         }, view, stackGetEdgeToIds);
 

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -396,9 +396,7 @@ export const createStore = ({
         }
     };
     const selectView = (...stack) => view => state => {
-        // let totalTime = 0;
         const assocPath = (path, val) => obj => {
-            // const res = R.assocPath(path, val, obj);
             let o = obj;
             for (let i = 0; i < path.length - 1; i += 1) {
                 const prop = path[i];
@@ -418,11 +416,9 @@ export const createStore = ({
 
         const [getViewTree, setViewTree, overViewTree] = useResult({});
         const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => {
-            // const start = performance.now();
             const res = reverse
                 ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)
                 : selectEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state);
-            // totalTime += performance.now() - start;
 
             return res;
         };
@@ -443,38 +439,8 @@ export const createStore = ({
                 }
 
                 overViewTree(assocPath(nodeViewPath, bag));
-
-                // const inclMeta = queryObj.metadata && edgePath; //  includeMetadata(queryObj) && edgePath;
-                // const inclNode = queryObj.node; //  includeNode(queryObj);
-                // const inclRights = queryObj.rights; //  includeRights(queryObj);
-                // const inclFiles = queryObj.files; //   includeFiles(queryObj);
-
-                // const start = performance.now();
-                // const bag = { nodeId };
-                // const meta = inclMeta && selectMetadata(...stack)(nodeId)(state);
-                // const node = inclNode && selectNode(...stack)(nodeId)(state);
-                // const rights = inclRights && selectRights(...stack)(nodeId)(state);
-                // const files = inclFiles && selectFiles(...stack)(nodeId)(state);
-                // totalTime += performance.now() - start;
-
-                // const start = performance.now();
-                // includeMetadata(queryObj) && edgePath && overViewTree(
-                //     assocPath([...nodeViewPath, 'metadata'], metadata),
-                // );
-                // includeNode(queryObj) && overViewTree(
-                //     assocPath([...nodeViewPath, 'node'], selectNode(...stack)(nodeId)(state)),
-                // );
-                // includeRights(queryObj) && overViewTree(
-                //     assocPath([...nodeViewPath, 'rights'], selectRights(...stack)(nodeId)(state)),
-                // );
-                // includeFiles(queryObj) && overViewTree(
-                //     assocPath([...nodeViewPath, 'files'], selectFiles(...stack)(nodeId)(state)),
-                // );
-                // totalTime += performance.now() - start;
             },
         }, view, stackGetEdgeToIds);
-
-        // console.log('time spent in node fn', totalTime);
 
         return getViewTree();
     };

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -398,13 +398,10 @@ export const createStore = ({
     };
     const selectView = (...stack) => view => state => {
         const [getViewTree, , overViewTree] = useResult({});
-        const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => {
-            const res = reverse
-                ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)
-                : selectEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state);
+        const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => reverse
+            ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)
+            : selectEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state);
 
-            return res;
-        };
         doViewGraph({
             nodes: (queryObj, nodeId, edgePath, nodeViewPath, metadata) => {
                 const bag = { nodeId };

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -397,7 +397,7 @@ export const createStore = ({
         }
     };
     const selectView = (...stack) => view => state => {
-        const [getViewTree, setViewTree, overViewTree] = useResult({});
+        const [getViewTree, , overViewTree] = useResult({});
         const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => {
             const res = reverse
                 ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -417,18 +417,32 @@ export const createStore = ({
         };
 
         const [getViewTree, setViewTree, overViewTree] = useResult({});
-        const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => reverse
-            ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)
-            : selectEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state);
+        const stackGetEdgeToIds = (fromType, nodeId, toType, { reverse } = {}) => {
+            // const start = performance.now();
+            const res = reverse
+                ? selectReverseEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state)
+                : selectEdge(...stack)(`${fromType}/${toType}`)(nodeId)(state);
+            // totalTime += performance.now() - start;
+
+            return res;
+        };
         doViewGraph({
             nodes: (queryObj, nodeId, edgePath, nodeViewPath, metadata) => {
-                const assocFn = assocPath(nodeViewPath, {
-                    nodeId,
-                });
+                const bag = { nodeId };
+                if (includeMetadata(queryObj) && edgePath) {
+                    bag.metadata = metadata;
+                }
+                if (includeNode(queryObj)) {
+                    bag.node = selectNode(...stack)(nodeId)(state);
+                }
+                if (includeRights(queryObj)) {
+                    bag.rights = selectRights(...stack)(nodeId)(state);
+                }
+                if (includeFiles(queryObj)) {
+                    bag.files = selectFiles(...stack)(nodeId)(state);
+                }
 
-                overViewTree(
-                    assocFn,
-                );
+                overViewTree(assocPath(nodeViewPath, bag));
 
                 // const inclMeta = queryObj.metadata && edgePath; //  includeMetadata(queryObj) && edgePath;
                 // const inclNode = queryObj.node; //  includeNode(queryObj);
@@ -443,19 +457,19 @@ export const createStore = ({
                 // const files = inclFiles && selectFiles(...stack)(nodeId)(state);
                 // totalTime += performance.now() - start;
 
-                const start = performance.now();
-                includeMetadata(queryObj) && edgePath && overViewTree(
-                    assocPath([...nodeViewPath, 'metadata'], metadata),
-                );
-                includeNode(queryObj) && overViewTree(
-                    assocPath([...nodeViewPath, 'node'], selectNode(...stack)(nodeId)(state)),
-                );
-                includeRights(queryObj) && overViewTree(
-                    assocPath([...nodeViewPath, 'rights'], selectRights(...stack)(nodeId)(state)),
-                );
-                includeFiles(queryObj) && overViewTree(
-                    assocPath([...nodeViewPath, 'files'], selectFiles(...stack)(nodeId)(state)),
-                );
+                // const start = performance.now();
+                // includeMetadata(queryObj) && edgePath && overViewTree(
+                //     assocPath([...nodeViewPath, 'metadata'], metadata),
+                // );
+                // includeNode(queryObj) && overViewTree(
+                //     assocPath([...nodeViewPath, 'node'], selectNode(...stack)(nodeId)(state)),
+                // );
+                // includeRights(queryObj) && overViewTree(
+                //     assocPath([...nodeViewPath, 'rights'], selectRights(...stack)(nodeId)(state)),
+                // );
+                // includeFiles(queryObj) && overViewTree(
+                //     assocPath([...nodeViewPath, 'files'], selectFiles(...stack)(nodeId)(state)),
+                // );
                 // totalTime += performance.now() - start;
             },
         }, view, stackGetEdgeToIds);

--- a/packages/got-store/src/index.js
+++ b/packages/got-store/src/index.js
@@ -11,7 +11,7 @@ import {
     overPath,
     useSubscriber,
     useResult,
-    mutAssocPath,
+    assocPathMutate,
 } from '@gothub-team/got-util';
 import {
     mergeOverwriteGraphsLeft,
@@ -418,7 +418,7 @@ export const createStore = ({
                     bag.files = selectFiles(...stack)(nodeId)(state);
                 }
 
-                overViewTree(mutAssocPath(nodeViewPath, bag));
+                overViewTree(assocPathMutate(nodeViewPath, bag));
             },
         }, view, stackGetEdgeToIds);
 

--- a/packages/got-store/src/tests/shared.js
+++ b/packages/got-store/src/tests/shared.js
@@ -1,4 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import * as R from 'ramda';
+import * as uuid from 'uuid';
 import { createStore, gotReducer } from '../index.js';
 
 export const createTestStore = (initialState = {}, api = undefined) => {
@@ -45,4 +47,54 @@ export const createTestStore = (initialState = {}, api = undefined) => {
         store,
         api: _api,
     };
+};
+
+export const generateRandomString = (length = 5) => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, length);
+
+export const generateRandomTestData = (numParents, numChildrenPerParent) => {
+    const {
+        store: { add },
+        getState,
+    } = createTestStore({ });
+
+    // generate debug data
+    for (let i = 0; i < numParents; i += 1) {
+        const parentId = uuid.v4();
+        const parent = {
+            id: parentId, createdDate: new Date().toISOString(), str: `${generateRandomString()}/${generateRandomString()}`, arr: [generateRandomString(), generateRandomString()],
+        };
+        add('main')('root/parent')('root')(parent);
+        for (let j = 0; j < numChildrenPerParent; j += 1) {
+            const childId = uuid.v4();
+            const child = {
+                id: childId, createdDate: new Date().toISOString(), bool: true, num: Math.random(),
+            };
+            add('main')('parent/child')(parentId)(child);
+        }
+    }
+    return getState();
+};
+
+export const randomTestDataView = {
+    'root': {
+        as: 'root',
+        edges: {
+            'root/parent': {
+                as: 'parents',
+                include: {
+                    node: true,
+                    edges: true,
+                },
+                edges: {
+                    'parent/child': {
+                        as: 'children',
+                        include: {
+                            node: true,
+                            edges: true,
+                        },
+                    },
+                },
+            },
+        },
+    },
 };

--- a/packages/got-store/src/tests/views.spec.js
+++ b/packages/got-store/src/tests/views.spec.js
@@ -761,7 +761,8 @@ describe('store:Views', () => {
     });
 
     describe('performance', () => {
-        test('should select 100 parent and 1000 child objects in under 10ms', () => {
+        // this should run much faster on local machines, but was increased from 10ms to 25ms to not fail tests in workflows
+        test('should select 100 parent and 1000 child objects in under 25ms', () => {
             const runTimes = 10;
             const generateRandomString = (length = 5) => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, length);
 
@@ -822,9 +823,9 @@ describe('store:Views', () => {
                 totalTime += end - start;
             }
 
-            console.log('ran in ', totalTime / runTimes, 'ms');
+            console.log('select view ran in ', totalTime / runTimes, 'ms');
 
-            expect(totalTime / runTimes).toBeLessThanOrEqual(10);
+            expect(totalTime / runTimes).toBeLessThanOrEqual(25);
         });
     });
 

--- a/packages/got-store/src/tests/views.spec.js
+++ b/packages/got-store/src/tests/views.spec.js
@@ -760,7 +760,7 @@ describe('store:Views', () => {
         });
     });
 
-    describe.only('performance', () => {
+    describe('performance', () => {
         test('should select 100 parent and 1000 child objects in under 10ms', () => {
             const runTimes = 10;
             const generateRandomString = (length = 5) => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, length);

--- a/packages/got-store/src/tests/views.spec.js
+++ b/packages/got-store/src/tests/views.spec.js
@@ -1,5 +1,4 @@
-import * as uuid from 'uuid';
-import { createTestStore } from './shared.js';
+import { createTestStore, generateRandomTestData, randomTestDataView } from './shared.js';
 import { MISSING_PARAM_ERROR } from '../errors.js';
 
 describe('store:Views', () => {
@@ -764,60 +763,18 @@ describe('store:Views', () => {
         // this should run much faster on local machines, but was increased from 10ms to 25ms to not fail tests in workflows
         test('should select 100 parent and 1000 child objects in under 25ms', () => {
             const runTimes = 10;
-            const generateRandomString = (length = 5) => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, length);
 
             let totalTime = 0;
             for (let counter = 0; counter < runTimes; counter += 1) {
                 const {
                     store: {
                         selectView,
-                        add,
                     },
                     select,
-                } = createTestStore({ });
-
-                // generate debug data
-                for (let i = 0; i < 100; i += 1) {
-                    const locationId = uuid.v4();
-                    const location = {
-                        id: locationId, createdDate: new Date().toISOString(), path: `${generateRandomString()}/${generateRandomString()}`, tags: [generateRandomString(), generateRandomString()],
-                    };
-                    add('main')('root/location')('root')(location);
-                    for (let j = 0; j < 10; j += 1) {
-                        const objectId = uuid.v4();
-                        const object = {
-                            id: objectId, createdDate: new Date().toISOString(), isAtLocation: true, name: generateRandomString(10), oldLocation: false,
-                        };
-                        add('main')('location/object')(locationId)(object);
-                    }
-                }
-
-                const view = {
-                    'root': {
-                        as: 'root',
-                        edges: {
-                            'root/location': {
-                                as: 'locations',
-                                include: {
-                                    node: true,
-                                    edges: true,
-                                },
-                                edges: {
-                                    'location/object': {
-                                        as: 'objects',
-                                        include: {
-                                            node: true,
-                                            edges: true,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                };
+                } = createTestStore(generateRandomTestData(100, 10));
 
                 const start = performance.now();
-                select(selectView('main', 'temp')(view));
+                select(selectView('main', 'temp')(randomTestDataView));
                 const end = performance.now();
 
                 totalTime += end - start;

--- a/packages/got-store/src/tests/views.spec.js
+++ b/packages/got-store/src/tests/views.spec.js
@@ -1,3 +1,4 @@
+import * as uuid from 'uuid';
 import { createTestStore } from './shared.js';
 import { MISSING_PARAM_ERROR } from '../errors.js';
 
@@ -756,6 +757,74 @@ describe('store:Views', () => {
 
             expect(dispatch).not.toBeCalled();
         /* #endregion */
+        });
+    });
+
+    describe.only('performance', () => {
+        test('should select 100 parent and 1000 child objects in under 10ms', () => {
+            const runTimes = 10;
+            const generateRandomString = (length = 5) => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, length);
+
+            let totalTime = 0;
+            for (let counter = 0; counter < runTimes; counter += 1) {
+                const {
+                    store: {
+                        selectView,
+                        add,
+                    },
+                    select,
+                } = createTestStore({ });
+
+                // generate debug data
+                for (let i = 0; i < 100; i += 1) {
+                    const locationId = uuid.v4();
+                    const location = {
+                        id: locationId, createdDate: new Date().toISOString(), path: `${generateRandomString()}/${generateRandomString()}`, tags: [generateRandomString(), generateRandomString()],
+                    };
+                    add('main')('root/location')('root')(location);
+                    for (let j = 0; j < 10; j += 1) {
+                        const objectId = uuid.v4();
+                        const object = {
+                            id: objectId, createdDate: new Date().toISOString(), isAtLocation: true, name: generateRandomString(10), oldLocation: false,
+                        };
+                        add('main')('location/object')(locationId)(object);
+                    }
+                }
+
+                const view = {
+                    'root': {
+                        as: 'root',
+                        edges: {
+                            'root/location': {
+                                as: 'locations',
+                                include: {
+                                    node: true,
+                                    edges: true,
+                                },
+                                edges: {
+                                    'location/object': {
+                                        as: 'objects',
+                                        include: {
+                                            node: true,
+                                            edges: true,
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                };
+
+                const start = performance.now();
+                select(selectView('main', 'temp')(view));
+                const end = performance.now();
+
+                totalTime += end - start;
+            }
+
+            console.log('ran in ', totalTime / runTimes, 'ms');
+
+            expect(totalTime / runTimes).toBeLessThanOrEqual(10);
         });
     });
 

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -130,4 +130,4 @@ export declare const getPath: (or: any, path: string[]) => (obj: Object) => any;
  * 
  * @returns the mutated object
  */
-export declare const mutAssocPath: (path: string[], val: any) => (obj: Object) => Object;
+export declare const assocPathMutate: (path: string[], val: any) => (obj: Object) => Object;

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -121,6 +121,11 @@ export declare const toPromise: (
  export declare const getPath: (path: string[], obj: Object) => any | undefined;
 
 /**
+ * @returns the property at a given path in the specified object or the given fallback if the path doesn't exist.
+ */
+export declare const getPath: (or: any, path: string[]) => (obj: Object) => any;
+
+/**
  * Will mutate an object and assoc the given value at the specified path, creating objects along the way if they don't exist yet.
  * 
  * @returns the mutated object

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -123,7 +123,7 @@ export declare const toPromise: (
 /**
  * @returns the property at a given path in the specified object or the given fallback if the path doesn't exist.
  */
-export declare const getPath: (or: any, path: string[]) => (obj: Object) => any;
+export declare const getPathOr: (or: any, path: string[]) => (obj: Object) => any;
 
 /**
  * Will mutate an object and assoc the given value at the specified path, creating objects along the way if they don't exist yet.

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -116,6 +116,11 @@ export declare const toPromise: (
     ) => Promise<any[]>;
 
 /**
+ * @returns the property at a given path in the specified object or undefined if the path doesn't exist.
+ */
+ export declare const getPath: (path: string[], obj: Object) => any | undefined;
+
+/**
  * Will mutate an object and assoc the given value at the specified path, creating objects along the way if they don't exist yet.
  * 
  * @returns the mutated object

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -105,3 +105,10 @@ export declare const forEachConfObj: (
 export declare const toPromise: (
     observable: { subscribe: (subscriber: Subscriber<any>) => void }
     ) => Promise<any[]>;
+
+/**
+ * Will mutate an object and assoc the given value at the specified path, creating objects along the way if they don't exist yet.
+ * 
+ * @returns the mutated object
+ */
+export declare const mutAssocPath: (path: string[], val: any) => (obj: Object) => Object;

--- a/packages/got-util/src/index.d.ts
+++ b/packages/got-util/src/index.d.ts
@@ -1,8 +1,17 @@
+
+export declare type FnGet = () => any;
+export declare type FnSet = (value: any) => any;
+export declare type FnOver = (fn: FnSet) => any;
+
 /**
- * returns a getter and a setter function for a reference.
+ * returns a getter, a setter and an over function for a reference.
  * Setter function can be invoked with either a new value or a function to be applied to the reference.
+ * Over function can only be invoked with a function to be applied to the reference.
+ * 
+ * While the Setter function includes the same functionality as the Over function,
+ * calling the Over function repeatedly is more efficient since it doesnt have to check for input type
  */
-export declare const useResult: (initialValue: any) => [() => any, any | ((value: any) => any)];
+export declare const useResult: (initialValue: any) => [fnGet: FnGet, fnSet: FnSet, fnOver: FnOver];
 
 export declare type Subscriber<TEvent> = {
     /**

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -3,13 +3,21 @@ import * as RA from 'ramda-adjunct';
 
 export const useResult = initialValue => {
     const reference = { current: initialValue };
+
+    const set = input => {
+        if (R.is(Function)) {
+            reference.current = input(reference.current);
+        } else {
+            reference.current = input;
+        }
+    };
+    const over = fn => {
+        reference.current = fn(reference.current);
+    };
     return [
         () => reference.current,
-        R.ifElse(
-            R.is(Function),
-            fnSet => reference.current = fnSet(reference.current),
-            newValue => reference.current = newValue,
-        ),
+        set,
+        over,
     ];
 };
 

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -146,20 +146,33 @@ export const toPromise = observable => new Promise((resolve, reject) => {
     });
 });
 
-export const mutAssocPath = (path, val) => obj => {
-    let o = obj;
+export const getPath = (path, input) => {
+    let obj = input;
+    for (let i = 0; i < path.length; i += 1) {
+        const key = path[i];
+        if (key in obj) {
+            obj = obj[key];
+        } else {
+            return undefined;
+        }
+    }
+    return obj;
+};
+
+export const mutAssocPath = (path, val) => input => {
+    let obj = input;
     for (let i = 0; i < path.length - 1; i += 1) {
         const prop = path[i];
-        if (prop in o) {
-            o = o[prop];
+        if (prop in obj) {
+            obj = obj[prop];
         } else {
-            o[prop] = {};
-            o = o[prop];
+            obj[prop] = {};
+            obj = obj[prop];
         }
     }
 
     const lastProp = path[path.length - 1];
-    o[lastProp] = val;
+    obj[lastProp] = val;
 
-    return obj;
+    return input;
 };

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -159,6 +159,19 @@ export const getPath = (path, input) => {
     return obj;
 };
 
+export const getPathOr = (or, path) => input => {
+    let obj = input;
+    for (let i = 0; i < path.length; i += 1) {
+        const key = path[i];
+        if (key in obj) {
+            obj = obj[key];
+        } else {
+            return or;
+        }
+    }
+    return obj;
+};
+
 export const mutAssocPath = (path, val) => input => {
     let obj = input;
     for (let i = 0; i < path.length - 1; i += 1) {

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -146,19 +146,6 @@ export const toPromise = observable => new Promise((resolve, reject) => {
     });
 });
 
-export const getPath = (path, input) => {
-    let obj = input;
-    for (let i = 0; i < path.length; i += 1) {
-        const key = path[i];
-        if (key in obj) {
-            obj = obj[key];
-        } else {
-            return undefined;
-        }
-    }
-    return obj;
-};
-
 export const getPathOr = (or, path) => input => {
     let obj = input;
     for (let i = 0; i < path.length; i += 1) {
@@ -171,6 +158,8 @@ export const getPathOr = (or, path) => input => {
     }
     return obj;
 };
+
+export const getPath = (path, input) => getPathOr(undefined, path)(input);
 
 export const mutAssocPath = (path, val) => input => {
     let obj = input;

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -145,3 +145,21 @@ export const toPromise = observable => new Promise((resolve, reject) => {
         error: e => reject(R.append(e, getResults())),
     });
 });
+
+export const mutAssocPath = (path, val) => obj => {
+    let o = obj;
+    for (let i = 0; i < path.length - 1; i += 1) {
+        const prop = path[i];
+        if (prop in o) {
+            o = o[prop];
+        } else {
+            o[prop] = {};
+            o = o[prop];
+        }
+    }
+
+    const lastProp = path[path.length - 1];
+    o[lastProp] = val;
+
+    return obj;
+};

--- a/packages/got-util/src/index.js
+++ b/packages/got-util/src/index.js
@@ -161,7 +161,7 @@ export const getPathOr = (or, path) => input => {
 
 export const getPath = (path, input) => getPathOr(undefined, path)(input);
 
-export const mutAssocPath = (path, val) => input => {
+export const assocPathMutate = (path, val) => input => {
     let obj = input;
     for (let i = 0; i < path.length - 1; i += 1) {
         const prop = path[i];

--- a/packages/got-util/src/index.spec.js
+++ b/packages/got-util/src/index.spec.js
@@ -1,4 +1,4 @@
-import { mergeRight } from './index.js';
+import { mutAssocPath, mergeRight } from './index.js';
 
 describe('mergeRight', () => {
     test('should merge two objects correctly', () => {
@@ -25,5 +25,82 @@ describe('mergeRight', () => {
         const result = mergeRight(obj1, obj2);
 
         expect(result).toEqual(obj1);
+    });
+});
+
+describe('mutAssocPath', () => {
+    test('should assoc at path with path length = 1', () => {
+        const obj = {};
+
+        const result = mutAssocPath(['prop'], 'value')(obj);
+        const expected = {
+            prop: 'value',
+        };
+
+        expect(result).toEqual(expected);
+    });
+    test('should not modify other properties with path length = 1 ', () => {
+        const obj = { ogProp: 'ogValue' };
+
+        const result = mutAssocPath(['prop'], 'value')(obj);
+        const expected = {
+            prop: 'value',
+            ogProp: 'ogValue',
+        };
+
+        expect(result).toEqual(expected);
+    });
+    test('should return same object instance with path length = 1 ', () => {
+        const obj = { ogProp: 'ogValue' };
+
+        const result = mutAssocPath(['prop'], 'value')(obj);
+
+        expect(obj === result).toBeTruthy();
+    });
+    test('should assoc at path with path length = 3', () => {
+        const obj = {};
+
+        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+        const expected = {
+            some: {
+                test: {
+                    path: 'value',
+                },
+            },
+        };
+
+        expect(result).toEqual(expected);
+    });
+    test('should not modify other properties with path length = 1 ', () => {
+        const obj = {
+            ogProp1: 'ogValue1',
+            some: {
+                ogProp2: 'ogValue2',
+                test: {
+                    ogProp3: 'ogValue3',
+                },
+            },
+        };
+
+        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+        const expected = {
+            ogProp1: 'ogValue1',
+            some: {
+                ogProp2: 'ogValue2',
+                test: {
+                    ogProp3: 'ogValue3',
+                    path: 'value',
+                },
+            },
+        };
+
+        expect(result).toEqual(expected);
+    });
+    test('should return same object instance with path length = 1 ', () => {
+        const obj = { ogProp: 'ogValue' };
+
+        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+
+        expect(obj === result).toBeTruthy();
     });
 });

--- a/packages/got-util/src/index.spec.js
+++ b/packages/got-util/src/index.spec.js
@@ -1,4 +1,4 @@
-import { mutAssocPath, mergeRight, getPath } from './index.js';
+import { getPathOr, mutAssocPath, mergeRight, getPath } from './index.js';
 
 describe('mergeRight', () => {
     test('should merge two objects correctly', () => {
@@ -100,6 +100,85 @@ describe('getPath', () => {
         const result2 = getPath(['some', 'invalid', 'path'], obj);
         const result3 = getPath(['some', 'test', 'invalid'], obj);
         const expected = undefined;
+
+        expect(result1).toEqual(expected);
+        expect(result2).toEqual(expected);
+        expect(result3).toEqual(expected);
+    });
+});
+
+describe('getPathOr', () => {
+    test('should get prop at path with path length = 1', () => {
+        const obj = {
+            prop: 'value',
+        };
+
+        const result = getPathOr('fallback', ['prop'])(obj);
+        const expected = 'value';
+
+        expect(result).toEqual(expected);
+    });
+    test('should return instance at path with path length = 1 ', () => {
+        const instance = { prop: 'value' };
+        const obj = {
+            prop: instance,
+        };
+
+        const result = getPathOr('fallback', ['prop'])(obj);
+
+        expect(result === instance).toBeTruthy();
+    });
+    test('should return fallback if path does not exist with path length = 1 ', () => {
+        const obj = {
+            prop: 'value',
+        };
+
+        const result = getPathOr('fallback', ['otherProp'])(obj);
+        const expected = 'fallback';
+
+        expect(result).toEqual(expected);
+    });
+    test('should get prop at path with path length = 3', () => {
+        const obj = {
+            some: {
+                test: {
+                    path: 'value',
+                },
+            },
+        };
+
+        const result = getPathOr('fallback', ['some', 'test', 'path'])(obj);
+        const expected = 'value';
+
+        expect(result).toEqual(expected);
+    });
+    test('should return instance at path with path length = 3 ', () => {
+        const instance = { prop: 'value' };
+        const obj = {
+            some: {
+                test: {
+                    path: instance,
+                },
+            },
+        };
+
+        const result = getPathOr('fallback', ['some', 'test', 'path'])(obj);
+
+        expect(result === instance).toBeTruthy();
+    });
+    test('should return undefined if path does not exist with path length = 3 ', () => {
+        const obj = {
+            some: {
+                test: {
+                    path: 'value',
+                },
+            },
+        };
+
+        const result1 = getPathOr('fallback', ['invalid', 'test', 'path'])(obj);
+        const result2 = getPathOr('fallback', ['some', 'invalid', 'path'])(obj);
+        const result3 = getPathOr('fallback', ['some', 'test', 'invalid'])(obj);
+        const expected = 'fallback';
 
         expect(result1).toEqual(expected);
         expect(result2).toEqual(expected);

--- a/packages/got-util/src/index.spec.js
+++ b/packages/got-util/src/index.spec.js
@@ -1,4 +1,4 @@
-import { getPathOr, mutAssocPath, mergeRight, getPath } from './index.js';
+import { getPathOr, assocPathMutate, mergeRight, getPath } from './index.js';
 
 describe('mergeRight', () => {
     test('should merge two objects correctly', () => {
@@ -186,11 +186,11 @@ describe('getPathOr', () => {
     });
 });
 
-describe('mutAssocPath', () => {
+describe('assocPathMutate', () => {
     test('should assoc at path with path length = 1', () => {
         const obj = {};
 
-        const result = mutAssocPath(['prop'], 'value')(obj);
+        const result = assocPathMutate(['prop'], 'value')(obj);
         const expected = {
             prop: 'value',
         };
@@ -200,7 +200,7 @@ describe('mutAssocPath', () => {
     test('should not modify other properties with path length = 1', () => {
         const obj = { ogProp: 'ogValue' };
 
-        const result = mutAssocPath(['prop'], 'value')(obj);
+        const result = assocPathMutate(['prop'], 'value')(obj);
         const expected = {
             prop: 'value',
             ogProp: 'ogValue',
@@ -211,14 +211,14 @@ describe('mutAssocPath', () => {
     test('should return same object instance with path length = 1', () => {
         const obj = { ogProp: 'ogValue' };
 
-        const result = mutAssocPath(['prop'], 'value')(obj);
+        const result = assocPathMutate(['prop'], 'value')(obj);
 
         expect(obj === result).toBeTruthy();
     });
     test('should assoc at path with path length = 3', () => {
         const obj = {};
 
-        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+        const result = assocPathMutate(['some', 'test', 'path'], 'value')(obj);
         const expected = {
             some: {
                 test: {
@@ -240,7 +240,7 @@ describe('mutAssocPath', () => {
             },
         };
 
-        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+        const result = assocPathMutate(['some', 'test', 'path'], 'value')(obj);
         const expected = {
             ogProp1: 'ogValue1',
             some: {
@@ -257,7 +257,7 @@ describe('mutAssocPath', () => {
     test('should return same object instance with path length = 3', () => {
         const obj = { ogProp: 'ogValue' };
 
-        const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);
+        const result = assocPathMutate(['some', 'test', 'path'], 'value')(obj);
 
         expect(obj === result).toBeTruthy();
     });

--- a/packages/got-util/src/index.spec.js
+++ b/packages/got-util/src/index.spec.js
@@ -1,4 +1,4 @@
-import { mutAssocPath, mergeRight } from './index.js';
+import { mutAssocPath, mergeRight, getPath } from './index.js';
 
 describe('mergeRight', () => {
     test('should merge two objects correctly', () => {
@@ -28,6 +28,85 @@ describe('mergeRight', () => {
     });
 });
 
+describe('getPath', () => {
+    test('should get prop at path with path length = 1', () => {
+        const obj = {
+            prop: 'value',
+        };
+
+        const result = getPath(['prop'], obj);
+        const expected = 'value';
+
+        expect(result).toEqual(expected);
+    });
+    test('should return instance at path with path length = 1 ', () => {
+        const instance = { prop: 'value' };
+        const obj = {
+            prop: instance,
+        };
+
+        const result = getPath(['prop'], obj);
+
+        expect(result === instance).toBeTruthy();
+    });
+    test('should return undefined if path does not exist with path length = 1 ', () => {
+        const obj = {
+            prop: 'value',
+        };
+
+        const result = getPath(['otherProp'], obj);
+        const expected = undefined;
+
+        expect(result).toEqual(expected);
+    });
+    test('should get prop at path with path length = 3', () => {
+        const obj = {
+            some: {
+                test: {
+                    path: 'value',
+                },
+            },
+        };
+
+        const result = getPath(['some', 'test', 'path'], obj);
+        const expected = 'value';
+
+        expect(result).toEqual(expected);
+    });
+    test('should return instance at path with path length = 3 ', () => {
+        const instance = { prop: 'value' };
+        const obj = {
+            some: {
+                test: {
+                    path: instance,
+                },
+            },
+        };
+
+        const result = getPath(['some', 'test', 'path'], obj);
+
+        expect(result === instance).toBeTruthy();
+    });
+    test('should return undefined if path does not exist with path length = 3 ', () => {
+        const obj = {
+            some: {
+                test: {
+                    path: 'value',
+                },
+            },
+        };
+
+        const result1 = getPath(['invalid', 'test', 'path'], obj);
+        const result2 = getPath(['some', 'invalid', 'path'], obj);
+        const result3 = getPath(['some', 'test', 'invalid'], obj);
+        const expected = undefined;
+
+        expect(result1).toEqual(expected);
+        expect(result2).toEqual(expected);
+        expect(result3).toEqual(expected);
+    });
+});
+
 describe('mutAssocPath', () => {
     test('should assoc at path with path length = 1', () => {
         const obj = {};
@@ -39,7 +118,7 @@ describe('mutAssocPath', () => {
 
         expect(result).toEqual(expected);
     });
-    test('should not modify other properties with path length = 1 ', () => {
+    test('should not modify other properties with path length = 1', () => {
         const obj = { ogProp: 'ogValue' };
 
         const result = mutAssocPath(['prop'], 'value')(obj);
@@ -50,7 +129,7 @@ describe('mutAssocPath', () => {
 
         expect(result).toEqual(expected);
     });
-    test('should return same object instance with path length = 1 ', () => {
+    test('should return same object instance with path length = 1', () => {
         const obj = { ogProp: 'ogValue' };
 
         const result = mutAssocPath(['prop'], 'value')(obj);
@@ -71,7 +150,7 @@ describe('mutAssocPath', () => {
 
         expect(result).toEqual(expected);
     });
-    test('should not modify other properties with path length = 1 ', () => {
+    test('should not modify other properties with path length = 3', () => {
         const obj = {
             ogProp1: 'ogValue1',
             some: {
@@ -96,7 +175,7 @@ describe('mutAssocPath', () => {
 
         expect(result).toEqual(expected);
     });
-    test('should return same object instance with path length = 1 ', () => {
+    test('should return same object instance with path length = 3', () => {
         const obj = { ogProp: 'ogValue' };
 
         const result = mutAssocPath(['some', 'test', 'path'], 'value')(obj);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,6 +1459,7 @@ __metadata:
     jest: ^28.1.0
     ramda: ^0.28.0
     ramda-adjunct: ^3.1.0
+    uuid: ^8.3.2
     webpack: ^5.72.1
     webpack-cli: 4.9.2
   languageName: unknown
@@ -6786,6 +6787,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
resolves #6 

## Changes
- Added cheaper util function versions of ramda functions
    - mutAssocPath: mutates the given object and returns it
    - getPath: gets the instance at the path
    - getPathOr: gets the instance at the path or the given fallback 
- Reworked selectPathFromStack to not use expensive immutable ramda functions as much where it is not necessary
    - this accelerates every select function of got-store
- Reworked useResult to return an over function as third element to make executing setter exclusively with functions faster
- Reworked selectView to not use expensive immutable ramda functions as much where it is not necessary
    - now using over function to mutate result instead of setter
    - now constructing bag as one object instead of associng every single bag prop, which is expensive
    - now using faster function to check if props should be included